### PR TITLE
Close the "0" loophole

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ branches:
   - /^release\/.*$/ # release branches
   - /^v[0-9]+\.[0-9]+\.[0-9]+$/ # version tags
 
+env:
+  global:
+    - JULIA_DEBUG="all"
+
 julia:
   - "1.2"
   - "1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RetroCap"
 uuid = "d77cfa7a-8890-4952-b292-ef424e435f4a"
 authors = ["Dilum Aluthge", "Brown Center for Biomedical Informatics"]
-version = "0.1.1"
+version = "0.2.0-DEV"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 [![Build Status](https://travis-ci.com/bcbi/RetroCap.jl.svg?branch=master)](https://travis-ci.com/bcbi/RetroCap.jl)
 [![Codecov](https://codecov.io/gh/bcbi/RetroCap.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/bcbi/RetroCap.jl)
 
-RetroCap retroactively add "caps" (upper-bounded compat entries) to all packages in a registry.
+RetroCap retroactively add "caps" (upper-bounded `[compat]` entries) to all
+packages in a registry.
 
-More specifically, RetroCap adds upper-bounded compat entries to every version of every package in a registry **except the latest version of each package**.
+More specifically, RetroCap adds upper-bounded `[compat]` entries to every
+version of every package in a
+registry **except the latest version of each package**.
 
 ## Installation
 ```julia
@@ -27,26 +30,19 @@ julia> using RetroCap
 julia> add_caps(NoUpperBound(), pwd())
 ```
 
-The `NoCompatEntry` strategy will only:
-1. Add compat entries if they are missing
-
-```julia
-julia> run(`git clone https://github.com/JuliaRegistries/General.git`)
-julia> cd("General")
-julia> using RetroCap
-julia> add_caps(NoCompatEntry(), pwd())
-```
-
 ### Run only on repos in a specific GitHub organization
+
+First, define an environment variable named `GITHUB_AUTH` that contains a
+GitHub personal access token. Then, run the following script:
 
 ```julia
 using GitHub
 
 using RetroCap
 
-auth = GitHub.authenticate("ENV["GITHUB_AUTH"]") # you need to set this in your ENV
+auth = GitHub.authenticate("ENV["GITHUB_AUTH"]")
 
-orgrepos = GitHub.repos("JuliaDiffEq", auth = auth)[1] # replace JuliaDiffEq with the name of your GitHub organization
+orgrepos, page_data = GitHub.repos("MY_GITHUB_ORGANIZATION", auth = auth)[1]
 
 run(`git clone https://github.com/JuliaRegistries/General.git`)
 
@@ -54,16 +50,21 @@ cd("General")
 
 pkgs = [RetroCap.Package(r.name[1:end-3]) for r in orgrepos]
 
-pkg_to_path, pkg_to_num_versions, pkg_to_latest_version = RetroCap.parse_registry(pwd())
+pkg_to_path,
+    pkg_to_num_versions,
+    pkg_to_latest_version,
+    pkg_to_latest_zero_version = RetroCap.parse_registry(pwd())
 
 for pkg in pkgs
     try
-        add_caps(NoUpperBound(),pwd(),
+        add_caps(NoUpperBound(),
+                 pwd(),
                  pkg_to_latest_version,
+                 pkg_to_latest_zero_version,
                  pkg,
                  pkg_to_path[pkg])
     catch
-        println("Package $pkg not affected")
+        println("Package $(pkg) not affected")
     end
 end
 ```

--- a/src/Compress.jl
+++ b/src/Compress.jl
@@ -13,7 +13,8 @@ Given `pool` as the pool of available versions (of some package) and `subset` as
 subset of the pool of available versions, this function computes a `VersionSpec` which
 includes all versions in `subset` and none of the versions in its complement.
 """
-function compress_versions(pool::Vector{VersionNumber}, subset::Vector{VersionNumber})
+@inline function compress_versions(pool::Vector{VersionNumber},
+                                   subset::Vector{VersionNumber})
     # Explicitly drop prerelease/build numbers, as those can confuse this.
     # TODO: Rewrite all this to use VersionNumbers instead of VersionBounds
     drop_build_prerelease(v::VersionNumber) = VersionNumber(v.major, v.minor, v.patch)
@@ -42,18 +43,18 @@ function compress_versions(pool::Vector{VersionNumber}, subset::Vector{VersionNu
     end
 end
 
-# function compress_versions(pool::Vector{VersionNumber}, subset)
+# @inline function compress_versions(pool::Vector{VersionNumber}, subset)
 #     compress_versions(pool, filter(in(subset), pool))
 # end
 
-function load_versions(path::String)
+@inline function load_versions(path::String)
     versions_file = joinpath(dirname(path), "Versions.toml")
     versions_dict = TOML.parsefile(versions_file)
     sort!([VersionNumber(v) for v in keys(versions_dict)])
 end
 
-function load(path::String,
-    versions::Vector{VersionNumber} = load_versions(path))
+@inline function load(path::String,
+                      versions::Vector{VersionNumber} = load_versions(path))
     compressed = TOML.parsefile(path)
     uncompressed = Dict{VersionNumber,Dict{Any,Any}}()
     for (vers, data) in compressed
@@ -66,8 +67,9 @@ function load(path::String,
     return uncompressed
 end
 
-function compress(path::String, uncompressed::Dict,
-    versions::Vector{VersionNumber} = load_versions(path))
+@inline function compress(path::String,
+                          uncompressed::Dict,
+                          versions::Vector{VersionNumber} = load_versions(path))
     inverted = Dict()
     for (ver, data) in uncompressed, (key, val) in data
         val isa TOML.TYPE || (val = string(val))
@@ -82,8 +84,9 @@ function compress(path::String, uncompressed::Dict,
     return compressed
 end
 
-function save(path::String, uncompressed::Dict,
-    versions::Vector{VersionNumber} = load_versions(path))
+@inline function save(path::String,
+                      uncompressed::Dict,
+                      versions::Vector{VersionNumber} = load_versions(path))
     compressed = compress(path, uncompressed)
     open(path, write=true) do io
         TOML.print(io, compressed, sorted=true)

--- a/src/RetroCap.jl
+++ b/src/RetroCap.jl
@@ -1,7 +1,6 @@
 module RetroCap
 
 export CapStrategy
-export NoCompatEntry
 export NoUpperBound
 export add_caps
 

--- a/src/add_caps.jl
+++ b/src/add_caps.jl
@@ -1,63 +1,73 @@
 import Pkg
 import UUIDs
 
-function add_caps(strategy::CapStrategy, registry_path::AbstractString)
+@inline function add_caps(strategy::CapStrategy,
+                          registry_path::AbstractString)
     _registry_path = convert(String, registry_path)::String
     add_caps(strategy, _registry_path)
     return nothing
 end
 
-function add_caps(strategy::CapStrategy, registry_path::String)
-    pkg_to_path, pkg_to_num_versions, pkg_to_latest_version = parse_registry(registry_path)
+@inline function add_caps(strategy::CapStrategy,
+                          registry_path::String)
+    pkg_to_path,
+        pkg_to_num_versions,
+        pkg_to_latest_version,
+        pkg_to_latest_zero_version = parse_registry(registry_path)
     add_caps(strategy,
              registry_path,
              pkg_to_path,
              pkg_to_num_versions,
-             pkg_to_latest_version)
+             pkg_to_latest_version,
+             pkg_to_latest_zero_version)
     return nothing
 end
 
-function add_caps(strategy::CapStrategy,
-                  registry_path::String,
-                  pkg_to_path::AbstractDict{Package, String},
-                  pkg_to_num_versions::AbstractDict{Package, Int},
-                  pkg_to_latest_version::AbstractDict{Package, VersionNumber})
-    for pkg in keys(pkg_to_path)
+@inline function add_caps(strategy::CapStrategy,
+                          registry_path::String,
+                          pkg_to_path::AbstractDict{Package, String},
+                          pkg_to_num_versions::AbstractDict{Package, Int},
+                          pkg_to_latest_version::AbstractDict{Package, VersionNumber},
+                          pkg_to_latest_zero_version::AbstractDict{Package, <:Union{VersionNumber, Nothing}})
+    all_pkgs = collect(keys(pkg_to_path))
+    n = length(all_pkgs)
+    for i = 1:n
+        pkg = all_pkgs[i]
+        @debug("Package $(i) of $(n)", pkg)
         pkg_path = pkg_to_path[pkg]::String
-        num_versions = pkg_to_num_versions[pkg]::Int
-        latest_version = pkg_to_latest_version[pkg]::VersionNumber
-        if num_versions > 1
-            add_caps(strategy,
-                     registry_path,
-                     pkg_to_latest_version,
-                     pkg,
-                     pkg_path)
-        end
+        add_caps(strategy,
+                 registry_path,
+                 pkg_to_latest_version,
+                 pkg_to_latest_zero_version,
+                 pkg,
+                 pkg_path)
     end
     return nothing
 end
 
-function add_caps(strategy::CapStrategy,
-                  registry_path::String,
-                  pkg_to_latest_version::AbstractDict{Package, VersionNumber},
-                  pkg::Package,
-                  pkg_path::String)
+@inline function add_caps(strategy::CapStrategy,
+                          registry_path::String,
+                          pkg_to_latest_version::AbstractDict{Package, VersionNumber},
+                          pkg_to_latest_zero_version::AbstractDict{Package, <:Union{VersionNumber, Nothing}},
+                          pkg::Package,
+                          pkg_path::String)
     all_versions = get_all_versions(registry_path, pkg_path)
-    latest_version = maximum(all_versions)
-
+    latest_version = _get_latest_version(all_versions)
     compat_toml = joinpath(registry_path, pkg_path, "Compat.toml")
     deps_toml = joinpath(registry_path, pkg_path, "Deps.toml")
-
     if isfile(compat_toml) && isfile(deps_toml)
         compat = Compress.load(compat_toml)
         deps = Compress.load(deps_toml)
-        for version in all_versions
+        m = length(all_versions)
+        for j = 1:m
+            version = all_versions[j]
             if version != latest_version
                 add_caps!(compat,
                           deps,
                           strategy,
                           registry_path,
                           pkg_to_latest_version,
+                          pkg_to_latest_zero_version,
                           pkg,
                           pkg_path,
                           version)
@@ -68,21 +78,28 @@ function add_caps(strategy::CapStrategy,
     return nothing
 end
 
-function add_caps!(compat::AbstractDict{VersionNumber, <:Any},
-                   deps::AbstractDict{VersionNumber, <:Any},
-                   strategy::CapStrategy,
-                   registry_path::String,
-                   pkg_to_latest_version::AbstractDict{Package, VersionNumber},
-                   pkg::Package,
-                   pkg_path::String,
-                   version::VersionNumber)
+@inline function add_caps!(compat::AbstractDict{VersionNumber, <:Any},
+                           deps::AbstractDict{VersionNumber, <:Any},
+                           strategy::CapStrategy,
+                           registry_path::String,
+                           pkg_to_latest_version::AbstractDict{Package, VersionNumber},
+                           pkg_to_latest_zero_version::AbstractDict{Package, <:Union{VersionNumber, Nothing}},
+                           pkg::Package,
+                           pkg_path::String,
+                           version::VersionNumber)
     if haskey(deps, version)
         always_assert(haskey(compat, version))
         for dep in keys(deps[version])
-            if !is_stdlib(dep)
+            if !is_stdlib(dep) && !is_jll(dep)
                 latest_dep_version = pkg_to_latest_version[Package(dep)]
+                latest_dep_zero_version = pkg_to_latest_zero_version[Package(dep)]
                 current_compat_for_dep = _strip(get(compat[version], dep, ""))
-                new_compat_for_dep = generate_compat_entry(strategy, current_compat_for_dep, latest_dep_version)
+                new_compat_for_dep = generate_compat_entry(pkg,
+                                                           Package(dep),
+                                                           strategy,
+                                                           current_compat_for_dep,
+                                                           latest_dep_version,
+                                                           latest_dep_zero_version)
                 compat[version][dep] = new_compat_for_dep
             end
         end

--- a/src/assert.jl
+++ b/src/assert.jl
@@ -1,6 +1,6 @@
 AlwaysAssertionError() = AlwaysAssertionError("")
 
-function always_assert(cond::Bool)
+@inline function always_assert(cond::Bool)
     cond || throw(AlwaysAssertionError())
     return nothing
 end

--- a/src/compat_entries.jl
+++ b/src/compat_entries.jl
@@ -1,32 +1,44 @@
 import Pkg
 import UUIDs
 
-function new_compat_entry(current_compat_entry::Vector,
-                          latest_dep_version::VersionNumber)::String
-    return new_compat_entry(latest_dep_version)
+@inline function new_compat_entry(current_compat_entry::Vector,
+                                  upper_version::VersionNumber)::String
+    return new_compat_entry(upper_version)
 end
 
-function new_compat_entry(current_compat_entry::String,
-                          latest_dep_version::VersionNumber)::String
-    myregex_1 = r"([\d]*)\.([\d]*)\.([\d]*)[\s]*-[\s]*\*"
-    if occursin(myregex_1, current_compat_entry)
-        m = match(myregex_1, current_compat_entry)
-        lower_bound = VersionNumber("$(m[1]).$(m[2]).$(m[3])")
-        return new_compat_entry(lower_bound, latest_dep_version)
-    else
-        return new_compat_entry(latest_dep_version)
-    end
-end
-
-function new_compat_entry(latest_dep_version::VersionNumber)::String
+@inline function new_compat_entry(latest_dep_version::VersionNumber)::String
     lower_bound = v"0"
     return new_compat_entry(lower_bound, latest_dep_version)
 end
 
-function _compute_cap_upper_bound(latest_dep_version::VersionNumber)::String
-    x = latest_dep_version.major
-    y = latest_dep_version.minor
-    z = latest_dep_version.patch
+@inline function _extract_lower_bound(current_compat_entry::String)::VersionNumber
+    myregex1 = r"([\d]*)\.([\d]*)\.([\d]*)[\s]*-[\s]*"
+    myregex2 = r"([\d]*)\.([\d]*)[\s]*-[\s]*"
+    myregex3 = r"(\d[\d]*)[\s]*-[\s]*"
+    if occursin(myregex1, current_compat_entry)
+        m1 = match(myregex1, current_compat_entry)
+        return VersionNumber("$(m1[1]).$(m1[2]).$(m1[3])")
+    elseif occursin(myregex2, current_compat_entry)
+        m2 = match(myregex2, current_compat_entry)
+        return VersionNumber("$(m2[1]).$(m2[2])")
+    elseif occursin(myregex3, current_compat_entry)
+        m3 = match(myregex3, current_compat_entry)
+        return VersionNumber("$(m3[1])")
+    else
+        return v"0"
+    end
+end
+
+@inline function new_compat_entry(current_compat_entry::String,
+                                  upper_version::VersionNumber)::String
+    lower_bound = _extract_lower_bound(current_compat_entry)
+    return new_compat_entry(lower_bound, upper_version)
+end
+
+@inline function _compute_cap_upper_bound(upper_version::VersionNumber)::String
+    x = upper_version.major
+    y = upper_version.minor
+    z = upper_version.patch
     if x == 0
         if y == 0 # x is 0 and y is 0
             return "0.0.$(z)"
@@ -38,29 +50,39 @@ function _compute_cap_upper_bound(latest_dep_version::VersionNumber)::String
     end
 end
 
-function new_compat_entry(lower_bound::VersionNumber,
-                          latest_dep_version::VersionNumber)::String
+@inline function new_compat_entry(lower_bound::VersionNumber,
+                                  upper_version::VersionNumber)::String
     a = lower_bound.major
     b = lower_bound.minor
     c = lower_bound.patch
-    upper_bound = _compute_cap_upper_bound(latest_dep_version)    
+    upper_bound = _compute_cap_upper_bound(upper_version)
     compat = "$(a).$(b).$(c) - $(upper_bound)"
     @assert Pkg.Types.VersionRange(compat) isa Pkg.Types.VersionRange
     return compat
 end
 
-function generate_compat_entry(strategy::CapStrategy,
-                               current_compat_entry::Union{Vector, String},
-                               latest_dep_version::VersionNumber)
+@inline function generate_compat_entry(pkg::Package,
+                                       dep::Package,
+                                       strategy::CapStrategy,
+                                       current_compat_entry::Union{Vector, String},
+                                       latest_dep_version::VersionNumber,
+                                       latest_dep_zero_version::Union{VersionNumber, Nothing})
     if length(current_compat_entry) == 0
-        return new_compat_entry(current_compat_entry, latest_dep_version)
+        return new_compat_entry(current_compat_entry,
+                                latest_dep_version)
     else
         spec = _entry_to_spec(current_compat_entry)
-        return generate_compat_entry(strategy, current_compat_entry, spec, latest_dep_version)
+        return generate_compat_entry(pkg,
+                                     dep,
+                                     strategy,
+                                     current_compat_entry,
+                                     spec,
+                                     latest_dep_version,
+                                     latest_dep_zero_version)
     end
 end
 
-function _entry_to_spec(current_compat_entry::String)::Pkg.Types.VersionSpec
+@inline function _entry_to_spec(current_compat_entry::String)::Pkg.Types.VersionSpec
     try
         return Pkg.Types.semver_spec(current_compat_entry)
     catch
@@ -71,7 +93,7 @@ function _entry_to_spec(current_compat_entry::String)::Pkg.Types.VersionSpec
     return spec
 end
 
-function _entry_to_spec(current_compat_entry::Vector{String})::Pkg.Types.VersionSpec
+@inline function _entry_to_spec(current_compat_entry::Vector{String})::Pkg.Types.VersionSpec
     n = length(current_compat_entry)
     ranges = Vector{Pkg.Types.VersionRange}(undef, n)
     for i = 1:n
@@ -80,26 +102,131 @@ function _entry_to_spec(current_compat_entry::Vector{String})::Pkg.Types.Version
     spec = Pkg.Types.VersionSpec(ranges)
 end
 
-function generate_compat_entry(::NoCompatEntry,
-                               current_compat_entry::Union{Vector, String},
-                               spec::Pkg.Types.VersionSpec,
-                               latest_dep_version::VersionNumber)
+@inline function generate_compat_entry(pkg::Package,
+                                       dep::Package,
+                                       strategy::NoUpperBound,
+                                       current_compat_entry::Union{Vector, String},
+                                       spec::Pkg.Types.VersionSpec,
+                                       latest_dep_version::VersionNumber,
+                                       latest_dep_zero_version::Union{VersionNumber, Nothing})
     always_assert( length(current_compat_entry) > 0 )
-    return current_compat_entry
-end
-
-function generate_compat_entry(::NoUpperBound,
-                               current_compat_entry::Union{Vector, String},
-                               spec::Pkg.Types.VersionSpec,
-                               latest_dep_version::VersionNumber)
-    always_assert( length(current_compat_entry) > 0 )
-    if has_upper_bound(spec)
-        return current_compat_entry
-    else
+    if is_unbounded_infinity(spec)
         return new_compat_entry(current_compat_entry, latest_dep_version)
+    elseif is_unbounded_bad_zero(spec)
+        if latest_dep_zero_version isa Nothing
+            return new_compat_entry(current_compat_entry, latest_dep_version)
+        else
+            return new_compat_entry(current_compat_entry, latest_dep_zero_version)
+        end
+    else
+        # if (next_breaking_release(latest_dep_version) in spec) | (next_breaking_release(latest_dep_zero_version) in spec)
+        #     msg = string("This is a bad compat entry because ",
+        #                  "it includes future (not-yet-released) ",
+        #                  "breaking releases. ",
+        #                  "Unfortunately, I am not smart enough to fix this ",
+        #                  "compat entry, so I am leaving it unmodified. ",
+        #                  "Please manually modify this compat entry.")
+        #     @warn(msg,
+        #           pkg,
+        #           dep,
+        #           strategy,
+        #           spec,
+        #           latest_dep_version,
+        #           latest_dep_zero_version,
+        #           next_breaking_release(latest_dep_version),
+        #           next_breaking_release(latest_dep_zero_version))
+        # end
+        # if too_many_breaking_zero_versions(spec)
+        #     msg = string("This is a bad compat entry because ",
+        #                  "it includes an infinite number of breaking ",
+        #                  "releases of the form `0.x`.",
+        #                  "Unfortunately, I am not smart enough to fix this ",
+        #                  "compat entry, so I am leaving it unmodified. ",
+        #                  "Please manually modify this compat entry.")
+        #     @warn(msg,
+        #           pkg,
+        #           dep,
+        #           strategy,
+        #           spec,
+        #           latest_dep_version,
+        #           latest_dep_zero_version,
+        #           next_breaking_release(latest_dep_version),
+        #           next_breaking_release(latest_dep_zero_version))
+        # end
+        return current_compat_entry
     end
 end
 
-function has_upper_bound(spec::Pkg.Types.VersionSpec)::Bool
-    return !(typemax(VersionNumber) in spec)
+function too_many_breaking_nonzero_versions(spec::Pkg.Types.VersionSpec, cutoff::Integer = 50)::Bool
+    num = 0
+    a = typemin(Base.VInt) : Base.VInt(1)       : Base.VInt(200_000)
+    b = typemin(Base.VInt) : Base.VInt(100_000) : typemax(Base.VInt)
+    for major in Iterators.flatten([a, b])
+        if VersionNumber(major, 0, 0) in spec
+            num += 1
+        end
+    end
+    if num >= cutoff
+        return true
+    else
+        return false
+    end
 end
+
+function too_many_breaking_zero_versions(spec::Pkg.Types.VersionSpec, cutoff::Integer = 50)::Bool
+    num = 0
+    a = typemin(Base.VInt) : Base.VInt(1)       : Base.VInt(200_000)
+    b = typemin(Base.VInt) : Base.VInt(100_000) : typemax(Base.VInt)
+    for minor in Iterators.flatten([a, b])
+        if VersionNumber(0, minor, 0) in spec
+            num += 1
+        end
+    end
+    if num >= cutoff
+        return true
+    else
+        return false
+    end
+end
+
+@inline function includes_infinity(spec::Pkg.Types.VersionSpec)::Bool
+    max_component = typemax(Base.VInt)
+    x = typemax(VersionNumber)
+    y = VersionNumber(max_component, max_component, max_component)
+    result = (x in spec) | (y in spec)
+    return result
+end
+
+@inline function includes_bad_zero(spec::Pkg.Types.VersionSpec)::Bool
+    max_component = typemax(Base.VInt)
+    a = VersionNumber(0, max_component, 0)
+    b = VersionNumber(0, max_component, max_component)
+    c = VersionNumber(1, 0, 0)
+    has_a_or_b = (a in spec) | (b in spec)
+    doesnt_have_c = !(c in spec)
+    result = has_a_or_b & doesnt_have_c
+    return result
+end
+
+@inline function is_unbounded_infinity(spec::Pkg.Types.VersionSpec)::Bool
+    # return includes_infinity(spec) | too_many_breaking_nonzero_versions(spec)
+    return includes_infinity(spec)
+end
+
+@inline function is_unbounded_bad_zero(spec::Pkg.Types.VersionSpec)::Bool
+    # return includes_bad_zero(spec) | too_many_breaking_zero_versions(spec)
+    return includes_bad_zero(spec)
+end
+
+@inline function next_breaking_release(latest_version::VersionNumber)::VersionNumber
+    if latest_version < v"1"
+        major = 0
+        minor = latest_version.minor + 1
+    else
+        major = latest_version.major + 1
+        minor = 0
+    end
+    return VersionNumber(major, minor, 0)
+end
+
+@inline next_breaking_release(::Nothing) = v"0.0.0"

--- a/src/parse_registry.jl
+++ b/src/parse_registry.jl
@@ -1,7 +1,8 @@
 import Pkg
 import UUIDs
 
-function get_all_versions(registry_path::String, pkg_path::String)::Vector{VersionNumber}
+@inline function get_all_versions(registry_path::String,
+                                  pkg_path::String)::Vector{VersionNumber}
     versions_toml = Pkg.TOML.parsefile(joinpath(registry_path, pkg_path, "Versions.toml"))
     all_versions = VersionNumber.(collect(keys(versions_toml)))
     unique!(all_versions)
@@ -9,34 +10,57 @@ function get_all_versions(registry_path::String, pkg_path::String)::Vector{Versi
     return all_versions
 end
 
-function parse_registry(registry_path::String)
+@inline function _get_latest_version(versions::AbstractVector{VersionNumber})
+    return maximum(versions)
+end
+
+@inline function _get_latest_zero_version(versions::AbstractVector{VersionNumber})
+    all_zero_versions = filter((x) -> (x < v"1"), versions)
+    if isempty(all_zero_versions)
+        return nothing
+    else
+        latest_zero_version = maximum(all_zero_versions)
+        always_assert(latest_zero_version < v"1")
+        return latest_zero_version
+    end
+end
+
+@inline function parse_registry(registry_path::String)
     pkg_to_path = Dict{Package, String}()
     pkg_to_num_versions = Dict{Package, Int}()
     pkg_to_latest_version = Dict{Package, VersionNumber}()
+    pkg_to_latest_zero_version = Dict{Package, Union{VersionNumber, Nothing}}()
     parse_registry!(pkg_to_path,
                     pkg_to_num_versions,
                     pkg_to_latest_version,
+                    pkg_to_latest_zero_version,
                     registry_path)
-    return pkg_to_path, pkg_to_num_versions, pkg_to_latest_version
+    return pkg_to_path,
+           pkg_to_num_versions,
+           pkg_to_latest_version,
+           pkg_to_latest_zero_version
 end
 
-function parse_registry!(pkg_to_path::AbstractDict{Package, String},
-                         pkg_to_num_versions::AbstractDict{Package, Int},
-                         pkg_to_latest_version::AbstractDict{Package, VersionNumber},
-                         registry_path::String)
+@inline function parse_registry!(pkg_to_path::AbstractDict{Package, String},
+                                 pkg_to_num_versions::AbstractDict{Package, Int},
+                                 pkg_to_latest_version::AbstractDict{Package, VersionNumber},
+                                 pkg_to_latest_zero_version::AbstractDict{Package, <:Union{VersionNumber, Nothing}},
+                                 registry_path::String)
     registry = Pkg.TOML.parsefile(joinpath(registry_path, "Registry.toml"))
     packages = registry["packages"]
     for p in packages
         name = p[2]["name"]
         pkg_path = p[2]["path"]
-        if !endswith(name, "_jll")
+        if !is_jll(name)
             all_versions = get_all_versions(registry_path, pkg_path)
             num_versions = length(all_versions)
-            latest_version = maximum(all_versions)
+            latest_version = _get_latest_version(all_versions)
+            latest_zero_version = _get_latest_zero_version(all_versions)
             pkg = Package(name)
             pkg_to_path[pkg] = pkg_path
             pkg_to_num_versions[pkg] = num_versions
             pkg_to_latest_version[pkg] = latest_version
+            pkg_to_latest_zero_version[pkg] = latest_zero_version
         end
     end
     return nothing

--- a/src/types.jl
+++ b/src/types.jl
@@ -7,9 +7,6 @@ end
 
 abstract type CapStrategy end
 
-struct NoCompatEntry <: CapStrategy
-end
-
 struct NoUpperBound <: CapStrategy
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,12 +1,12 @@
 import Pkg
 import UUIDs
 
-function _strip(s::AbstractString)::String
+@inline function _strip(s::AbstractString)::String
     result::String = convert(String, strip(s))::String
     return result
 end
 
-function _strip(v::AbstractVector{<:AbstractString})::Vector{String}
+@inline function _strip(v::AbstractVector{<:AbstractString})::Vector{String}
     result::Vector{String} = Vector{String}(undef, 0)
     for i = 1:length(v)
         v_i_stripped = _strip(v[i])::String
@@ -17,11 +17,15 @@ function _strip(v::AbstractVector{<:AbstractString})::Vector{String}
     return result
 end
 
-@inline function is_stdlib(name::String)::Bool
-    return name in values(Pkg.Types.stdlib())
+@inline function is_stdlib(name::AbstractString)::Bool
+     return strip(name) in values(Pkg.Types.stdlib())
 end
 
-function with_temp_dir(f::Function)
+@inline function is_jll(name::AbstractString)::Bool
+    return endswith(lowercase(strip(name)), "_jll")
+end
+
+@inline function with_temp_dir(f::Function)
     original_dir = pwd()
     tmp_dir = mktempdir()
     atexit(() -> rm(tmp_dir; force = true, recursive = true))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,18 +25,75 @@ Test.@testset "RetroCap.jl" begin
             Test.@test RetroCap._compute_cap_upper_bound(v"0.0.3") == "0.0.3"
             Test.@test RetroCap._compute_cap_upper_bound(v"0.0.0") == "0.0.0"
         end
+        Test.@testset "_extract_lower_bound" begin
+            Test.@test RetroCap._extract_lower_bound("1.2.3 - foo") == v"1.2.3"
+            Test.@test RetroCap._extract_lower_bound("1.2 - foo") == v"1.2"
+            Test.@test RetroCap._extract_lower_bound("1 - foo") == v"1"
+            Test.@test RetroCap._extract_lower_bound(" - foo") == v"0"
+        end
+        Test.@testset "generate_compat_entry" begin
+            Test.@test "0.0.0 - 1" == RetroCap.generate_compat_entry(RetroCap.Package("PkgA"),
+                                                                     RetroCap.Package("PkgB"),
+                                                                     RetroCap.NoUpperBound(),
+                                                                     "0",
+                                                                     Pkg.Types.semver_spec("0"),
+                                                                     v"1.2.3",
+                                                                     nothing)
+        end
+        Test.@testset "too_many_breaking_nonzero_versions" begin
+            Test.@test !RetroCap.too_many_breaking_nonzero_versions(Pkg.Types.semver_spec("0"))
+            Test.@test RetroCap.too_many_breaking_nonzero_versions(Pkg.Types.semver_spec(">=1.2.3"))
+        end
+        Test.@testset "too_many_breaking_zero_versions" begin
+            Test.@test RetroCap.too_many_breaking_zero_versions(Pkg.Types.semver_spec("0"))
+            Test.@test !RetroCap.too_many_breaking_zero_versions(Pkg.Types.semver_spec(">=1.2.3"))
+        end
+        Test.@testset "next_breaking_release" begin
+            Test.@test v"0.0.0" == RetroCap.next_breaking_release(nothing)
+            Test.@test v"0.2.0" == RetroCap.next_breaking_release(v"0.1.0")
+            Test.@test v"2.0.0" == RetroCap.next_breaking_release(v"1.0.0")
+        end
     end
     Test.@testset "Run on the General registry" begin
         RetroCap.with_temp_dir() do tmp_dir
             cd(tmp_dir)
             run(`git clone https://github.com/JuliaRegistries/General.git`)
             cd("General")
-            RetroCap.add_caps(RetroCap.NoCompatEntry(), strip(pwd()))
-        end
-        RetroCap.with_temp_dir() do tmp_dir
-            cd(tmp_dir)
-            run(`git clone https://github.com/JuliaRegistries/General.git`)
-            cd("General")
+            a = joinpath("D", "DiffEqPhysics", "Compat.toml")
+            rm(a)
+            open(a, "w") do io
+                s = """
+[2]
+OrdinaryDiffEq = "3-5"
+julia = "0.7-1"
+
+["2-3.1"]
+DiffEqBase = "3-5"
+DiffEqCallbacks = "0-2"
+ForwardDiff = "0.5.0 - 0.10"
+RecipesBase = "0.0.0 - 0.7"
+RecursiveArrayTools = "0.0.0 - 0.20"
+Reexport = "0.0.0 - 0.2"
+StaticArrays = "0.0.0 - 0.12"
+
+["3.0"]
+julia = "0.7-1"
+
+["3.1-3"]
+julia = "1"
+
+["3.3-3"]
+DiffEqBase = "6.5.0-6"
+DiffEqCallbacks = "2.9.0-2"
+ForwardDiff = "0.10"
+RecipesBase = "0.7"
+RecursiveArrayTools = "1"
+Reexport = "0.2"
+StaticArrays = "0.10-0.12"
+                """
+                println(io, strip(s))
+                println(io)
+            end
             RetroCap.add_caps(RetroCap.NoUpperBound(), strip(pwd()))
         end
     end


### PR DESCRIPTION
Before this PR:
- `PkgA = "0"` is considered to be upper-bounded
- `PkgA = ">= 1.2.3"` is considered to NOT be upper-bounded

After this PR:
- `PkgA = "0"` is considered to NOT be upper-bounded
- `PkgA = ">= 1.2.3"` is considered to NOT be upper-bounded

This is a breaking change.

---

## Motivation

The compat entry `PkgA = "0"` represents `[0.0.0, 1.0.0)`. So technically, it has an upper-bound. But because `0.x.0` to `0.(x+1).0` is allowed to be a breaking change, the range `[0.0.0, 1.0.0)` contains infinitely many breaking releases. So we really shouldn't consider `[0.0.0, 1.0.0)` to be upper-bounded.