### PR TITLE
Fix instructions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RetroCap"
 uuid = "d77cfa7a-8890-4952-b292-ef424e435f4a"
 authors = ["Dilum Aluthge", "Brown Center for Biomedical Informatics"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,14 @@ run(`git clone https://github.com/JuliaRegistries/General.git`)
 
 cd("General")
 
-pkgs = [RetroCap.Package(r.name[1:end-3]) for r in orgrepos]
+pkgs = RetroCap.Package[]
+for r in orgrepos
+    name = r.name
+    if endswith(name, ".jl")
+        push!(pkgs, RetroCap.Package(name[1:end-3]))
+    end
+end
+unique!(pkgs)
 
 pkg_to_path,
     pkg_to_num_versions,


### PR DESCRIPTION
The current instructions for running RetroCap on all packages in your organization will fail if your GitHub organization includes any repos that are not Julia packages.

This PR fixes the instructions to exclude those repos.