### PR TITLE
Remove forced inlining

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RetroCap"
 uuid = "d77cfa7a-8890-4952-b292-ef424e435f4a"
 authors = ["Dilum Aluthge", "Brown Center for Biomedical Informatics", "Tim Holy", "contributors"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/add_caps.jl
+++ b/src/add_caps.jl
@@ -2,17 +2,17 @@ import Pkg
 import RegistryTools
 import UUIDs
 
-@inline function add_caps(strategy::CapStrategy,
-                          option::LatestVersionOption,
-                          registry_path::AbstractString)
+function add_caps(strategy::CapStrategy,
+                  option::LatestVersionOption,
+                  registry_path::AbstractString)
     _registry_paths = Any[registry_path]
     add_caps(strategy, option, _registry_paths)
     return nothing
 end
 
-@inline function add_caps(strategy::CapStrategy,
-                          option::LatestVersionOption,
-                          registry_paths::AbstractVector)
+function add_caps(strategy::CapStrategy,
+                  option::LatestVersionOption,
+                  registry_paths::AbstractVector)
     _registry_paths = Vector{String}(undef, 0)
     for path in registry_paths
         push!(_registry_paths, strip(path))
@@ -21,9 +21,9 @@ end
     return nothing
 end
 
-@inline function add_caps(strategy::CapStrategy,
-                          option::LatestVersionOption,
-                          registry_paths::Vector{String})
+function add_caps(strategy::CapStrategy,
+                  option::LatestVersionOption,
+                  registry_paths::Vector{String})
     pkg_to_path,
         pkg_to_num_versions,
         pkg_to_latest_version,
@@ -38,13 +38,13 @@ end
     return nothing
 end
 
-@inline function add_caps(strategy::CapStrategy,
-                          option::LatestVersionOption,
-                          registry_paths::Vector{String},
-                          pkg_to_path::AbstractDict{Package, String},
-                          pkg_to_num_versions::AbstractDict{Package, Int},
-                          pkg_to_latest_version::AbstractDict{Package, VersionNumber},
-                          pkg_to_latest_zero_version::AbstractDict{Package, <:Union{VersionNumber, Nothing}})
+function add_caps(strategy::CapStrategy,
+                  option::LatestVersionOption,
+                  registry_paths::Vector{String},
+                  pkg_to_path::AbstractDict{Package, String},
+                  pkg_to_num_versions::AbstractDict{Package, Int},
+                  pkg_to_latest_version::AbstractDict{Package, VersionNumber},
+                  pkg_to_latest_zero_version::AbstractDict{Package, <:Union{VersionNumber, Nothing}})
     all_pkgs = collect(keys(pkg_to_path))
     n = length(all_pkgs)
     for i = 1:n
@@ -62,13 +62,13 @@ end
     return nothing
 end
 
-@inline function add_caps(strategy::CapStrategy,
-                          option::LatestVersionOption,
-                          registry_paths::Vector{String},
-                          pkg_to_latest_version::AbstractDict{Package, VersionNumber},
-                          pkg_to_latest_zero_version::AbstractDict{Package, <:Union{VersionNumber, Nothing}},
-                          pkg::Package,
-                          pkg_path::String)
+function add_caps(strategy::CapStrategy,
+                  option::LatestVersionOption,
+                  registry_paths::Vector{String},
+                  pkg_to_latest_version::AbstractDict{Package, VersionNumber},
+                  pkg_to_latest_zero_version::AbstractDict{Package, <:Union{VersionNumber, Nothing}},
+                  pkg::Package,
+                  pkg_path::String)
     all_versions = get_all_versions(pkg_path)
     latest_version = _get_latest_version(all_versions)
     compat_toml = joinpath(pkg_path, "Compat.toml")
@@ -96,13 +96,13 @@ end
     return nothing
 end
 
-@inline function add_caps(strategy::MonotonicUpperBound,
-                          option::LatestVersionOption,
-                          registry_paths::Vector{String},
-                          pkg_to_latest_version::AbstractDict{Package, VersionNumber},
-                          pkg_to_latest_zero_version::AbstractDict{Package, <:Union{VersionNumber, Nothing}},
-                          pkg::Package,
-                          pkg_path::String)
+function add_caps(strategy::MonotonicUpperBound,
+                  option::LatestVersionOption,
+                  registry_paths::Vector{String},
+                  pkg_to_latest_version::AbstractDict{Package, VersionNumber},
+                  pkg_to_latest_zero_version::AbstractDict{Package, <:Union{VersionNumber, Nothing}},
+                  pkg::Package,
+                  pkg_path::String)
     option isa CapLatestVersion || error("MonotonicUpperBound requires CapLatestVersion")
     all_versions = get_all_versions(pkg_path)
     latest_version = _get_latest_version(all_versions)
@@ -146,15 +146,15 @@ end
     return nothing
 end
 
-@inline function add_caps!(compat::AbstractDict{VersionNumber, <:Any},
-                           deps::AbstractDict{VersionNumber, <:Any},
-                           strategy::CapStrategy,
-                           registry_paths::Vector{String},
-                           pkg_to_latest_version::AbstractDict{Package, VersionNumber},
-                           pkg_to_latest_zero_version::AbstractDict{Package, <:Union{VersionNumber, Nothing}},
-                           pkg::Package,
-                           pkg_path::String,
-                           version::VersionNumber)
+function add_caps!(compat::AbstractDict{VersionNumber, <:Any},
+                   deps::AbstractDict{VersionNumber, <:Any},
+                   strategy::CapStrategy,
+                   registry_paths::Vector{String},
+                   pkg_to_latest_version::AbstractDict{Package, VersionNumber},
+                   pkg_to_latest_zero_version::AbstractDict{Package, <:Union{VersionNumber, Nothing}},
+                   pkg::Package,
+                   pkg_path::String,
+                   version::VersionNumber)
     if haskey(deps, version)
         get!(() -> Dict{Any, Any}(), compat, version)
         always_assert(haskey(compat, version), "haskey(compat, version); pkg=$(pkg)")

--- a/src/assert.jl
+++ b/src/assert.jl
@@ -1,4 +1,4 @@
-@inline function always_assert(cond::Bool, msg::String)
+function always_assert(cond::Bool, msg::String)
     cond || throw(AlwaysAssertionError(msg))
     return nothing
 end

--- a/src/compat_entries.jl
+++ b/src/compat_entries.jl
@@ -1,17 +1,17 @@
 import Pkg
 import UUIDs
 
-@inline function new_compat_entry(current_compat_entry::Vector,
+function new_compat_entry(current_compat_entry::Vector,
                                   upper_version::VersionNumber)::String
     return new_compat_entry(upper_version)
 end
 
-@inline function new_compat_entry(latest_dep_version::VersionNumber)::String
+function new_compat_entry(latest_dep_version::VersionNumber)::String
     lower_bound = v"0"
     return new_compat_entry(lower_bound, latest_dep_version)
 end
 
-@inline function _extract_lower_bound(current_compat_entry::String)::VersionNumber
+function _extract_lower_bound(current_compat_entry::String)::VersionNumber
     myregex1 = r"([\d]*)\.([\d]*)\.([\d]*)[\s]*-[\s]*"
     myregex2 = r"([\d]*)\.([\d]*)[\s]*-[\s]*"
     myregex3 = r"(\d[\d]*)[\s]*-[\s]*"
@@ -29,13 +29,13 @@ end
     end
 end
 
-@inline function new_compat_entry(current_compat_entry::String,
-                                  upper_version::VersionNumber)::String
+function new_compat_entry(current_compat_entry::String,
+                          upper_version::VersionNumber)::String
     lower_bound = _extract_lower_bound(current_compat_entry)
     return new_compat_entry(lower_bound, upper_version)
 end
 
-@inline function _compute_cap_upper_bound(upper_version::VersionNumber)::String
+function _compute_cap_upper_bound(upper_version::VersionNumber)::String
     x = upper_version.major
     y = upper_version.minor
     z = upper_version.patch
@@ -50,8 +50,8 @@ end
     end
 end
 
-@inline function new_compat_entry(lower_bound::VersionNumber,
-                                  upper_version::VersionNumber)::String
+function new_compat_entry(lower_bound::VersionNumber,
+                          upper_version::VersionNumber)::String
     a = lower_bound.major
     b = lower_bound.minor
     c = lower_bound.patch
@@ -61,12 +61,12 @@ end
     return compat
 end
 
-@inline function generate_compat_entry(pkg::Package,
-                                       dep::Package,
-                                       strategy::CapStrategy,
-                                       current_compat_entry::Union{Vector, String},
-                                       latest_dep_version::VersionNumber,
-                                       latest_dep_zero_version::Union{VersionNumber, Nothing})
+function generate_compat_entry(pkg::Package,
+                               dep::Package,
+                               strategy::CapStrategy,
+                               current_compat_entry::Union{Vector, String},
+                               latest_dep_version::VersionNumber,
+                               latest_dep_zero_version::Union{VersionNumber, Nothing})
     if length(current_compat_entry) == 0
         return new_compat_entry(current_compat_entry,
                                 latest_dep_version)
@@ -82,7 +82,7 @@ end
     end
 end
 
-@inline function _entry_piece_to_ranges(piece::String)::Vector{Pkg.Types.VersionRange}
+function _entry_piece_to_ranges(piece::String)::Vector{Pkg.Types.VersionRange}
     try
         return Pkg.Types.semver_spec(piece).ranges
     catch
@@ -91,7 +91,7 @@ end
     return Pkg.Types.VersionRange[r]
 end
 
-@inline function _entry_to_spec(current_compat_entry::String)::Pkg.Types.VersionSpec
+function _entry_to_spec(current_compat_entry::String)::Pkg.Types.VersionSpec
     try
         return Pkg.Types.semver_spec(current_compat_entry)
     catch
@@ -105,7 +105,7 @@ end
     return spec
 end
 
-@inline function _entry_to_spec(current_compat_entry::Vector{String})::Pkg.Types.VersionSpec
+function _entry_to_spec(current_compat_entry::Vector{String})::Pkg.Types.VersionSpec
     n = length(current_compat_entry)
     ranges = Vector{Pkg.Types.VersionRange}(undef, n)
     for i = 1:n
@@ -114,13 +114,13 @@ end
     spec = Pkg.Types.VersionSpec(ranges)
 end
 
-@inline function generate_compat_entry(pkg::Package,
-                                       dep::Package,
-                                       strategy::UpperBound,
-                                       current_compat_entry::Union{Vector, String},
-                                       spec::Pkg.Types.VersionSpec,
-                                       latest_dep_version::VersionNumber,
-                                       latest_dep_zero_version::Union{VersionNumber, Nothing})
+function generate_compat_entry(pkg::Package,
+                               dep::Package,
+                               strategy::UpperBound,
+                               current_compat_entry::Union{Vector, String},
+                               spec::Pkg.Types.VersionSpec,
+                               latest_dep_version::VersionNumber,
+                               latest_dep_zero_version::Union{VersionNumber, Nothing})
     always_assert(length(current_compat_entry) > 0, "length(current_compat_entry) > 0; pkg=$(pkg), dep=$(dep)")
     if is_unbounded_infinity(spec)
         return new_compat_entry(current_compat_entry, latest_dep_version)
@@ -201,7 +201,7 @@ function too_many_breaking_zero_versions(spec::Pkg.Types.VersionSpec, cutoff::In
     end
 end
 
-@inline function includes_infinity(spec::Pkg.Types.VersionSpec)::Bool
+function includes_infinity(spec::Pkg.Types.VersionSpec)::Bool
     max_component = typemax(Base.VInt)
     x = typemax(VersionNumber)
     y = VersionNumber(max_component, max_component, max_component)
@@ -209,7 +209,7 @@ end
     return result
 end
 
-@inline function includes_bad_zero(spec::Pkg.Types.VersionSpec)::Bool
+function includes_bad_zero(spec::Pkg.Types.VersionSpec)::Bool
     max_component = typemax(Base.VInt)
     a = VersionNumber(0, max_component, 0)
     b = VersionNumber(0, max_component, max_component)
@@ -220,17 +220,17 @@ end
     return result
 end
 
-@inline function is_unbounded_infinity(spec::Pkg.Types.VersionSpec)::Bool
+function is_unbounded_infinity(spec::Pkg.Types.VersionSpec)::Bool
     # return includes_infinity(spec) | too_many_breaking_nonzero_versions(spec)
     return includes_infinity(spec)
 end
 
-@inline function is_unbounded_bad_zero(spec::Pkg.Types.VersionSpec)::Bool
+function is_unbounded_bad_zero(spec::Pkg.Types.VersionSpec)::Bool
     # return includes_bad_zero(spec) | too_many_breaking_zero_versions(spec)
     return includes_bad_zero(spec)
 end
 
-@inline function next_breaking_release(latest_version::VersionNumber)::VersionNumber
+function next_breaking_release(latest_version::VersionNumber)::VersionNumber
     if latest_version < v"1"
         major = 0
         minor = latest_version.minor + 1
@@ -241,7 +241,7 @@ end
     return VersionNumber(major, minor, 0)
 end
 
-@inline next_breaking_release(::Nothing) = v"0.0.0"
+next_breaking_release(::Nothing) = v"0.0.0"
 
 function monotonize!(pkgbounds, compat)
     for (dep, bnd) in compat

--- a/src/parse_registry.jl
+++ b/src/parse_registry.jl
@@ -1,7 +1,7 @@
 import Pkg
 import UUIDs
 
-@inline function get_all_versions(pkg_path::String)::Vector{VersionNumber}
+function get_all_versions(pkg_path::String)::Vector{VersionNumber}
     versions_toml = Pkg.TOML.parsefile(joinpath(pkg_path, "Versions.toml"))
     all_versions = VersionNumber.(collect(keys(versions_toml)))
     unique!(all_versions)
@@ -9,11 +9,11 @@ import UUIDs
     return all_versions
 end
 
-@inline function _get_latest_version(versions::AbstractVector{VersionNumber})
+function _get_latest_version(versions::AbstractVector{VersionNumber})
     return maximum(versions)
 end
 
-@inline function _get_latest_zero_version(versions::AbstractVector{VersionNumber})
+function _get_latest_zero_version(versions::AbstractVector{VersionNumber})
     all_zero_versions = filter((x) -> (x < v"1"), versions)
     if isempty(all_zero_versions)
         return nothing
@@ -24,7 +24,7 @@ end
     end
 end
 
-@inline function parse_registry(registry_paths::Vector{String})
+function parse_registry(registry_paths::Vector{String})
     pkg_to_path = Dict{Package, String}()
     pkg_to_num_versions = Dict{Package, Int}()
     pkg_to_latest_version = Dict{Package, VersionNumber}()
@@ -40,11 +40,11 @@ end
            pkg_to_latest_zero_version
 end
 
-@inline function parse_registry!(pkg_to_path::AbstractDict{Package, String},
-                                 pkg_to_num_versions::AbstractDict{Package, Int},
-                                 pkg_to_latest_version::AbstractDict{Package, VersionNumber},
-                                 pkg_to_latest_zero_version::AbstractDict{Package, <:Union{VersionNumber, Nothing}},
-                                 registry_paths::Vector{String})
+function parse_registry!(pkg_to_path::AbstractDict{Package, String},
+                         pkg_to_num_versions::AbstractDict{Package, Int},
+                         pkg_to_latest_version::AbstractDict{Package, VersionNumber},
+                         pkg_to_latest_zero_version::AbstractDict{Package, <:Union{VersionNumber, Nothing}},
+                         registry_paths::Vector{String})
     for path in registry_paths
         parse_registry!(pkg_to_path,
                         pkg_to_num_versions,
@@ -58,11 +58,11 @@ end
            pkg_to_latest_zero_version
 end
 
-@inline function parse_registry!(pkg_to_path::AbstractDict{Package, String},
-                                 pkg_to_num_versions::AbstractDict{Package, Int},
-                                 pkg_to_latest_version::AbstractDict{Package, VersionNumber},
-                                 pkg_to_latest_zero_version::AbstractDict{Package, <:Union{VersionNumber, Nothing}},
-                                 registry_path::String)
+function parse_registry!(pkg_to_path::AbstractDict{Package, String},
+                         pkg_to_num_versions::AbstractDict{Package, Int},
+                         pkg_to_latest_version::AbstractDict{Package, VersionNumber},
+                         pkg_to_latest_zero_version::AbstractDict{Package, <:Union{VersionNumber, Nothing}},
+                         registry_path::String)
     registry = Pkg.TOML.parsefile(joinpath(registry_path, "Registry.toml"))
     packages = registry["packages"]
     for p in packages

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,12 +1,12 @@
 import Pkg
 import UUIDs
 
-@inline function _strip(s::AbstractString)::String
+function _strip(s::AbstractString)::String
     result::String = convert(String, strip(s))::String
     return result
 end
 
-@inline function _strip(v::AbstractVector{<:AbstractString})::Vector{String}
+function _strip(v::AbstractVector{<:AbstractString})::Vector{String}
     result::Vector{String} = Vector{String}(undef, 0)
     for i = 1:length(v)
         v_i_stripped = _strip(v[i])::String
@@ -17,16 +17,16 @@ end
     return result
 end
 
-@inline function is_stdlib(name::AbstractString)::Bool
+function is_stdlib(name::AbstractString)::Bool
     _stdlibs = Pkg.Types.stdlibs()
     return strip(name) in values(_stdlibs)
 end
 
-@inline function is_jll(name::AbstractString)::Bool
+function is_jll(name::AbstractString)::Bool
     return endswith(lowercase(strip(name)), "_jll")
 end
 
-@inline function with_temp_dir(f::Function)
+function with_temp_dir(f::Function)
     original_dir = pwd()
     tmp_dir = mktempdir()
     atexit(() -> rm(tmp_dir; force = true, recursive = true))


### PR DESCRIPTION
Most of these functions wouldn't benefit from inlining,
and it just bloats the size of the generated code.
Better to let the compiler decide what is worth inlining.