### PR TITLE
Add a single-package convenience method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RetroCap"
 uuid = "d77cfa7a-8890-4952-b292-ef424e435f4a"
 authors = ["Dilum Aluthge", "Brown Center for Biomedical Informatics", "Tim Holy", "contributors"]
-version = "2.0.2"
+version = "2.1.0"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ julia> using RetroCap
 julia> add_caps(UpperBound(), ExcludeLatestVersion(), pwd())
 ```
 
+### Run for a single package
+
+Navigate to the directory of a `git` clone of the registry (see the example above for "General") and then
+
+```julia
+julia> using RetroCap
+julia> add_caps(MonotonicUpperBound(), CapLatestVersion(), pwd(), RetroCap.Package("MyRegisteredPackage"))
+```
+
 ### Run only on repos in a specific GitHub organization
 
 ```julia

--- a/src/add_caps.jl
+++ b/src/add_caps.jl
@@ -23,6 +23,25 @@ end
 
 function add_caps(strategy::CapStrategy,
                   option::LatestVersionOption,
+                  registry_path::AbstractString,
+                  pkg::Package)
+    _registry_paths = String[registry_path]
+    pkg_to_path,
+        pkg_to_num_versions,
+        pkg_to_latest_version,
+        pkg_to_latest_zero_version = parse_registry(_registry_paths)
+    add_caps(strategy,
+             option,
+             _registry_paths,
+             pkg_to_latest_version,
+             pkg_to_latest_zero_version,
+             pkg,
+             pkg_to_path[pkg])
+    return nothing
+end
+
+function add_caps(strategy::CapStrategy,
+                  option::LatestVersionOption,
                   registry_paths::Vector{String})
     pkg_to_path,
         pkg_to_num_versions,


### PR DESCRIPTION
RetroCap was motivated by the need to fix [compat] throughout the
General registry; however, today, most of the applications of RetroCap
may be to fix isolated instances of [compat] problems for a single
package. This adds an easier way to execute such fixes.