### PR TITLE
Update the TagBot configuration

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,10 +1,17 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 0 * * *
+  issue_comment:
+    types:
+      - created
   workflow_dispatch:
+    inputs:
+      lookback:
+        default: 3
+permissions:
+  contents: write
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1


### PR DESCRIPTION
This updates the TagBot config to match the latest config from https://github.com/JuliaRegistries/TagBot/blob/master/example.yml

This should make sure that the workflow isn't automatically disabled by GitHub after 60 days of inactivity, because the new workflow doesn't have a `cron`/`schedule` job.

Ref https://github.com/JuliaRegistries/RetroCap.jl/issues/56